### PR TITLE
Responsys modifications

### DIFF
--- a/lib/sidekiq/grouping/actor.rb
+++ b/lib/sidekiq/grouping/actor.rb
@@ -9,23 +9,53 @@ module Sidekiq
       end
 
       private
-      
+
       def start_polling
+        return unless Sidekiq::Grouping::Config.enabled
         interval = Sidekiq::Grouping::Config.poll_interval
         info "Start polling of queue batches every #{interval} seconds"
         every(interval) { flush_batches }
       end
 
       def flush_batches
-        batches = []
+        methods = {}
 
         Sidekiq::Grouping::Batch.all.map do |batch|
-          if batch.could_flush?
-            batches << batch
+          next unless batch.could_flush?
+
+          method_name = batch.worker_class.to_s
+
+          unless methods[method_name]
+            methods[method_name] = {
+              batches: [],
+              records: 0
+            }
           end
+
+          methods[method_name][:batches] << batch
+          methods[method_name][:records] += batch.size
         end
 
-        flush(batches)
+        methods.each do |method, options|
+          job_class = method.classify.constantize
+          max_records_per_call = job_class.get_sidekiq_options["max_records_per_call"] || Sidekiq::Grouping::Config.max_records_per_call
+          max_calls_per_minute = job_class.get_sidekiq_options["max_calls_per_minute"] || Sidekiq::Grouping::Config.max_calls_per_minute
+
+          number_of_calls = options[:records] / max_records_per_call
+          number_of_calls += 1 if options[:records] % max_records_per_call > 0
+
+          if number_of_calls > max_calls_per_minute
+            number_of_records_to_process = max_calls_per_minute * max_records_per_call
+          else
+            number_of_records_to_process = options[:records]
+          end
+
+          records_per_queue = number_of_records_to_process / options[:batches].length
+
+          methods[method][:flushable_records] = records_per_queue
+        end
+
+        flush(methods)
       end
 
       def link_to_sidekiq_manager
@@ -36,11 +66,19 @@ module Sidekiq
         after(5) { link_to_sidekiq_manager }
       end
 
-      def flush(batches)
-        if batches.any?
-          names = batches.map { |batch| "#{batch.worker_class} in #{batch.queue}" }
+      # The 'methods' argument should be like {
+      # "WorkerName": {
+      #   batches: ["WorkerName:queue_option:queue", "WorkerName2:queue_option2:queue2"],
+      #   flushable_records_per_queue: 50 }
+      # }
+      def flush(methods)
+        return unless methods.any?
+
+        methods.each do |method, options|
+          names = options[:batches].map { |batch| "#{batch.worker_class} in #{batch.queue} with option #{batch.queue_option}" }
           info "Trying to flush batched queues: #{names.join(',')}"
-          batches.each { |batch| batch.flush }
+
+          options[:batches].each { |batch| batch.flush(options[:flushable_records]) }
         end
       end
     end

--- a/lib/sidekiq/grouping/actor.rb
+++ b/lib/sidekiq/grouping/actor.rb
@@ -41,21 +41,25 @@ module Sidekiq
           max_records_per_call = job_class.get_sidekiq_options["max_records_per_call"] || Sidekiq::Grouping::Config.max_records_per_call
           max_calls_per_minute = job_class.get_sidekiq_options["max_calls_per_minute"] || Sidekiq::Grouping::Config.max_calls_per_minute
 
-          number_of_calls = options[:records] / max_records_per_call
-          number_of_calls += 1 if options[:records] % max_records_per_call > 0
-
-          if number_of_calls > max_calls_per_minute
-            number_of_records_to_process = max_calls_per_minute * max_records_per_call
-          else
-            number_of_records_to_process = options[:records]
-          end
-
-          records_per_queue = number_of_records_to_process / options[:batches].length
+          records_per_queue = calculate_records_per_queue(max_records_per_call, max_calls_per_minute, options[:records], options[:batches].length)
 
           methods[method][:flushable_records] = records_per_queue
         end
 
         flush(methods)
+      end
+
+      def calculate_records_per_queue(max_records_per_call, max_calls_per_minute, number_of_records, number_of_batch)
+        number_of_calls = number_of_records / max_records_per_call
+        number_of_calls += 1 if number_of_records % max_records_per_call > 0
+
+        if number_of_calls > max_calls_per_minute
+          number_of_records_to_process = max_calls_per_minute * max_records_per_call
+        else
+          number_of_records_to_process = number_of_records
+        end
+
+        number_of_records_to_process / number_of_batch
       end
 
       def link_to_sidekiq_manager

--- a/lib/sidekiq/grouping/batch.rb
+++ b/lib/sidekiq/grouping/batch.rb
@@ -36,6 +36,8 @@ module Sidekiq
       def flush(size)
         return unless (chunk = pluck(size))
 
+        info "Flushing #{@name} of #{size} records"
+
         group_size = worker_class_options['max_records_per_call'] || Sidekiq::Grouping::Config.max_records_per_call
 
         Sidekiq::Client.push(
@@ -67,7 +69,7 @@ module Sidekiq
       end
 
       def next_execution_time
-        interval = worker_class_options['batch_flush_interval'] || Sidekiq::Grouping::Config.default_flush_interval
+        interval = worker_class_options['batch_flush_interval'] || Sidekiq::Grouping::Config.batch_flush_interval
         last_time = last_execution_time
         last_time + interval.seconds if last_time
       end

--- a/lib/sidekiq/grouping/config.rb
+++ b/lib/sidekiq/grouping/config.rb
@@ -3,16 +3,24 @@ module Sidekiq
     module Config
       include ActiveSupport::Configurable
 
-      # Queue size overflow check polling interval
-      config_accessor :poll_interval
+      config_accessor :enabled, :poll_interval, :default_flush_interval, :max_records_per_call, :max_calls_per_minute, :lock_ttl
+
+      ### Default values ###
+      self.config.enabled = true
+
+      # Queue check polling interval
       self.config.poll_interval = 3
 
-      # Maximum batch size
-      config_accessor :max_batch_size
-      self.config.max_batch_size = 1000
+      # Flush the queue every x seconds
+      self.config.default_flush_interval = 60
+
+      # How many records max should be grouped together
+      self.config.max_records_per_call = 200
+
+      # How many calls can be made per minute
+      self.config.max_calls_per_minute = 30
 
       # Batch queue flush lock timeout
-      config_accessor :lock_ttl
       self.config.lock_ttl = 1
     end
   end

--- a/lib/sidekiq/grouping/config.rb
+++ b/lib/sidekiq/grouping/config.rb
@@ -3,7 +3,7 @@ module Sidekiq
     module Config
       include ActiveSupport::Configurable
 
-      config_accessor :enabled, :poll_interval, :default_flush_interval, :max_records_per_call, :max_calls_per_minute, :lock_ttl
+      config_accessor :enabled, :poll_interval, :batch_flush_interval, :max_records_per_call, :max_calls_per_minute, :lock_ttl
 
       ### Default values ###
       self.config.enabled = true
@@ -12,7 +12,7 @@ module Sidekiq
       self.config.poll_interval = 3
 
       # Flush the queue every x seconds
-      self.config.default_flush_interval = 60
+      self.config.batch_flush_interval = 60
 
       # How many records max should be grouped together
       self.config.max_records_per_call = 200

--- a/lib/sidekiq/grouping/middleware.rb
+++ b/lib/sidekiq/grouping/middleware.rb
@@ -5,21 +5,20 @@ module Sidekiq
         worker_class = worker_class.classify.constantize if worker_class.is_a?(String)
         options = worker_class.get_sidekiq_options
 
-        batch =
-          options.keys.include?('batch_flush_size') ||
-          options.keys.include?('batch_flush_interval')
+        batch = options['grouping'] && options['grouping'] == true
 
         passthrough =
           msg['args'] &&
           msg['args'].is_a?(Array) &&
           msg['args'].try(:first) == true
 
-        retrying = msg["failed_at"].present?
+        retrying = msg['failed_at'].present?
 
         return yield unless batch
 
         if !(passthrough || retrying)
-          add_to_batch(worker_class, queue, msg, redis_pool)
+          queue_option = msg['args'].first
+          add_to_batch(worker_class, queue, queue_option, msg, redis_pool)
         else
           msg['args'].shift if passthrough
           yield
@@ -28,9 +27,9 @@ module Sidekiq
 
       private
 
-      def add_to_batch(worker_class, queue, msg, redis_pool = nil)
+      def add_to_batch(worker_class, queue, queue_option, msg, redis_pool = nil)
         Sidekiq::Grouping::Batch
-          .new(worker_class.name, queue, redis_pool)
+          .new(worker_class.name, queue, queue_option, redis_pool)
           .add(msg['args'])
 
         nil

--- a/lib/sidekiq/grouping/views/index.erb
+++ b/lib/sidekiq/grouping/views/index.erb
@@ -1,41 +1,43 @@
-<header class="row">
-  <div class="col-sm-5">
-    <h3>Grouped jobs</h3>
-  </div>
-</header>
+<% @queues.each do |queue, batches| %>
+  <header class="row">
+    <div class="col-sm-5">
+      <h3>Queue '<%= queue %>'</h3>
+    </div>
+  </header>
 
-<div class="container">
-  <div class="row">
-    <div class="col-sm-12">
-      <% if true %>
-      <table class="table table-striped table-bordered table-white" style="width: 100%; margin: 0; table-layout:fixed;">
-        <thead>
-          <th style="width: 50%">Worker</th>
-          <th style="width: 30%">Queue</th>
-          <th style="width: 10%">Count</th>
-          <th style="width: 30%">Last execution time</th>
-          <th style="width: 30%">Next enqueue</th>
-          <th style="width: 10%">Actions</th>
-        </thead>
-        <% @batches.each do |batch| %>
-        <tr>
-          <td><%= batch.worker_class %></td>
-          <td><%= batch.queue %></td>
-          <td><%= batch.size %></td>
-          <td><%= batch.last_execution_time || "&ndash;"%></td>
-          <td><%= batch.next_execution_time || "&ndash;"%></td>
-          <td>
-            <form action="<%= "#{root_path}grouping/#{batch.name}/delete" %>" method="post">
-              <input class="btn btn-danger btn-xs" type="submit" name="delete" value="Delete" data-confirm="Are you sure you want to delete this batch?" />
-            </form>
-          </td>
-        </tr>
+  <div class="container">
+    <div class="row">
+      <div class="col-sm-12">
+        <% if true %>
+          <table class="table table-striped table-bordered table-white" style="width: 100%; margin: 0; table-layout:fixed;">
+            <thead>
+              <th style="width: 40%">Worker</th>
+              <th style="width: 40%">Options</th>
+              <th style="width: 10%">Count</th>
+              <th style="width: 30%">Last execution time</th>
+              <th style="width: 30%">Next enqueue</th>
+              <th style="width: 10%">Actions</th>
+            </thead>
+            <% batches.each do |batch| %>
+              <tr>
+                <td><%= batch.worker_class %></td>
+                <td><%= batch.queue_option %></td>
+                <td><%= batch.size %></td>
+                <td><%= batch.last_execution_time || "&ndash;"%></td>
+                <td><%= batch.next_execution_time || "&ndash;"%></td>
+                <td>
+                  <form action="<%= "#{root_path}grouping/#{batch.name}/delete" %>" method="post">
+                    <input class="btn btn-danger btn-xs" type="submit" name="delete" value="Delete" data-confirm="Are you sure you want to delete this batch?" />
+                  </form>
+                </td>
+              </tr>
+            <% end %>
+          </table>
+        <% else %>
+          <div class="alert alert-success">No recurring jobs found.</div>
         <% end %>
-      </table>
-      <% else %>
-      <div class="alert alert-success">No recurring jobs found.</div>
-      <% end %>
+      </div>
     </div>
   </div>
-</div>
 
+<% end %>

--- a/lib/sidekiq/grouping/web.rb
+++ b/lib/sidekiq/grouping/web.rb
@@ -7,13 +7,13 @@ module Sidetiq
 
       def self.registered(app)
         app.get "/grouping" do
-          @batches = Sidekiq::Grouping::Batch.all
+          @queues = Sidekiq::Grouping::Batch.all_by_queue
           erb File.read(File.join(VIEWS, 'index.erb')), locals: {view_path: VIEWS}
         end
 
         app.post "/grouping/:name/delete" do
-          worker_class, queue = Sidekiq::Grouping::Batch.extract_worker_klass_and_queue(params['name'])
-          batch = Sidekiq::Grouping::Batch.new(worker_class, queue)
+          worker_class, option, queue = Sidekiq::Grouping::Batch.extract_worker_info(params["name"])
+          batch = Sidekiq::Grouping::Batch.new(worker_class, option, queue)
           batch.delete
           redirect "#{root_path}/grouping"
         end
@@ -25,4 +25,3 @@ end
 
 Sidekiq::Web.register(Sidetiq::Grouping::Web)
 Sidekiq::Web.tabs["Grouping"] = "grouping"
-

--- a/spec/modules/actor_spec.rb
+++ b/spec/modules/actor_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe Sidekiq::Grouping::Actor do
+  subject { Sidekiq::Grouping::Actor }
+
+  before(:each) do
+    allow_any_instance_of(described_class).to receive(:link_to_sidekiq_manager)
+  end
+
+  context 'calculate_records_per_queue' do
+    context 'scenario 1' do
+      let(:max_records_per_call) { 7 }
+      let(:max_calls_per_minute) { 3 }
+      let(:records_to_process) { 37 }
+      let(:number_of_batch) { 4 }
+
+      it 'should return 5' do
+        params = [max_records_per_call, max_calls_per_minute, records_to_process, number_of_batch]
+
+        result = subject.new.send(:calculate_records_per_queue, *params)
+
+        expect(result).to eq(5)
+      end
+    end
+
+    context 'scenario 2' do
+      let(:max_records_per_call) { 200 }
+      let(:max_calls_per_minute) { 1000 }
+      let(:records_to_process) { 379 }
+      let(:number_of_batch) { 5 }
+
+      it 'should return 75' do
+        params = [max_records_per_call, max_calls_per_minute, records_to_process, number_of_batch]
+
+        result = subject.new.send(:calculate_records_per_queue, *params)
+
+        expect(result).to eq(75)
+      end
+    end
+
+    context 'scenario 2' do
+      let(:max_records_per_call) { 20 }
+      let(:max_calls_per_minute) { 100 }
+      let(:records_to_process) { 7892 }
+      let(:number_of_batch) { 8 }
+
+      it 'should return 250' do
+        params = [max_records_per_call, max_calls_per_minute, records_to_process, number_of_batch]
+
+        result = subject.new.send(:calculate_records_per_queue, *params)
+
+        expect(result).to eq(250)
+      end
+    end
+  end
+end

--- a/spec/modules/batch_spec.rb
+++ b/spec/modules/batch_spec.rb
@@ -5,108 +5,78 @@ describe Sidekiq::Grouping::Batch do
 
   context 'adding' do
     it 'must enqueue unbatched worker' do
-       RegularWorker.perform_async('bar')
-       expect(RegularWorker).to have_enqueued_job('bar')
+       RegularWorker.perform_async('foo_option', 'bar')
+       expect(RegularWorker).to have_enqueued_job('foo_option', 'bar')
     end
 
     it 'must not enqueue batched worker' do
-      BatchedSizeWorker.perform_async('bar')
-      expect_batch(BatchedSizeWorker, 'batched_size')
-    end
-
-    it 'must not enqueue batched worker' do
-      BatchedIntervalWorker.perform_async('bar')
-      expect_batch(BatchedIntervalWorker, 'batched_interval')
-    end
-
-    it 'must not enqueue batched worker' do
-      BatchedBothWorker.perform_async('bar')
-      expect_batch(BatchedBothWorker, 'batched_both')
+      BatchedSizeWorker.perform_async('foo_option', 'bar')
+      expect_batch(BatchedSizeWorker, 'batched_size', 'foo_option')
     end
   end
 
   context 'checking if should flush' do
-    it 'must flush if limit exceeds for limit worker' do
-      batch = subject.new(BatchedSizeWorker.name, 'batched_size')
+    it 'should check this scenario' do
+      batch = subject.new(BatchedSizeWorker.name, 'batched_size', 'foo_option')
 
+      # empty batch, the dates are not set.
       expect(batch.could_flush?).to be_falsy
-      BatchedSizeWorker.perform_async('bar')
+      BatchedSizeWorker.perform_async('foo_option', 'bar')
+      # non empty batch, dates are initiated but the batch is not flushed
       expect(batch.could_flush?).to be_falsy
-      4.times { BatchedSizeWorker.perform_async('bar') }
-      expect(batch.could_flush?).to be_truthy
-    end
-
-    it 'must flush if limit exceeds for both worker' do
-      batch = subject.new(BatchedBothWorker.name, 'batched_both')
-
-      expect(batch.could_flush?).to be_falsy
-      BatchedBothWorker.perform_async('bar')
-      expect(batch.could_flush?).to be_falsy
-      4.times { BatchedBothWorker.perform_async('bar') }
-      expect(batch.could_flush?).to be_truthy
-    end
-
-    it 'must flush if limit okay but time came' do
-      batch = subject.new(BatchedIntervalWorker.name, 'batched_interval')
-
-      expect(batch.could_flush?).to be_falsy
-      BatchedIntervalWorker.perform_async('bar')
-      expect(batch.could_flush?).to be_falsy
-      expect(batch.size).to eq(1)
-
-      Timecop.travel(2.hours.since)
-
+      Timecop.travel(1.minute.since)
+      # we are 1min from the last check with a non empty batch => flushable
       expect(batch.could_flush?).to be_truthy
     end
   end
 
   context 'flushing' do
-    it 'must put wokrer to queue on flush' do
-      batch = subject.new(BatchedSizeWorker.name, 'batched_size')
+    it 'must put worker to queue on flush' do
+      batch = subject.new(BatchedSizeWorker.name, 'batched_size', 'foo_option')
 
       expect(batch.could_flush?).to be_falsy
-      10.times { |n| BatchedSizeWorker.perform_async("bar#{n}") }
-      batch.flush
-      expect(BatchedSizeWorker).to have_enqueued_job([["bar0"], ["bar1"]])
-      expect(batch.size).to eq(7)
+      10.times { |n| BatchedSizeWorker.perform_async('foo_option', "bar#{n}") }
+      batch.flush(2)
+      expect(BatchedSizeWorker).to have_enqueued_job({ "queue_option" => "foo_option", "chunks" => [[["foo_option", "bar0"], ["foo_option", "bar1"]]] })
+      expect(batch.size).to eq(8)
     end
   end
 
   context 'with similar args' do
     context 'option batch_unique = true' do
       it 'enqueues once' do
-        batch = subject.new(BatchedUniqueArgsWorker.name, 'batched_unique_args')
-        3.times { BatchedUniqueArgsWorker.perform_async('bar', 1) }
+        batch = subject.new(BatchedUniqueArgsWorker.name, 'batched_unique_args', 'foo_option')
+        3.times { BatchedUniqueArgsWorker.perform_async('foo_option', 'bar', 1) }
         expect(batch.size).to eq(1)
       end
 
       it 'enqueues once each unique set of args' do
-        batch = subject.new(BatchedUniqueArgsWorker.name, 'batched_unique_args')
-        3.times { BatchedUniqueArgsWorker.perform_async('bar', 1) }
-        6.times { BatchedUniqueArgsWorker.perform_async('baz', 1) }
-        3.times { BatchedUniqueArgsWorker.perform_async('bar', 1) }
-        2.times { BatchedUniqueArgsWorker.perform_async('baz', 3) }
-        7.times { BatchedUniqueArgsWorker.perform_async('bar', 1) }
+        batch = subject.new(BatchedUniqueArgsWorker.name, 'batched_unique_args', 'foo_option')
+        3.times { BatchedUniqueArgsWorker.perform_async('foo_option', 'bar', 1) }
+        6.times { BatchedUniqueArgsWorker.perform_async('foo_option', 'baz', 1) }
+        3.times { BatchedUniqueArgsWorker.perform_async('foo_option', 'bar', 1) }
+        2.times { BatchedUniqueArgsWorker.perform_async('foo_option', 'baz', 3) }
+        7.times { BatchedUniqueArgsWorker.perform_async('foo_option', 'bar', 1) }
         expect(batch.size).to eq(3)
       end
 
       context 'flushing' do
 
         it 'works' do
-          batch = subject.new(BatchedUniqueArgsWorker.name, 'batched_unique_args')
-          2.times { BatchedUniqueArgsWorker.perform_async('bar', 1) }
-          2.times { BatchedUniqueArgsWorker.perform_async('baz', 1) }
-          batch.flush
+          batch = subject.new(BatchedUniqueArgsWorker.name, 'batched_unique_args', 'foo_option')
+          2.times { BatchedUniqueArgsWorker.perform_async('foo_option' 'bar', 1) }
+          2.times { BatchedUniqueArgsWorker.perform_async('foo_option', 'baz', 1) }
+          batch.flush(batch.size)
           expect(batch.size).to eq(0)
         end
 
         it 'allows to enqueue again after flush' do
-          batch = subject.new(BatchedUniqueArgsWorker.name, 'batched_unique_args')
-          2.times { BatchedUniqueArgsWorker.perform_async('bar', 1) }
-          2.times { BatchedUniqueArgsWorker.perform_async('baz', 1) }
-          batch.flush
-          BatchedUniqueArgsWorker.perform_async('bar', 1)
-          BatchedUniqueArgsWorker.perform_async('baz', 1)
+          batch = subject.new(BatchedUniqueArgsWorker.name, 'batched_unique_args', 'foo_option')
+          2.times { BatchedUniqueArgsWorker.perform_async('foo_option', 'bar', 1) }
+          2.times { BatchedUniqueArgsWorker.perform_async('foo_option', 'baz', 1) }
+          batch.flush(batch.size)
+          BatchedUniqueArgsWorker.perform_async('foo_option', 'bar', 1)
+          BatchedUniqueArgsWorker.perform_async('foo_option', 'baz', 1)
           expect(batch.size).to eq(2)
         end
       end
@@ -115,22 +85,22 @@ describe Sidekiq::Grouping::Batch do
 
     context 'batch_unique is not specified' do
       it 'enqueues all' do
-        batch = subject.new(BatchedSizeWorker.name, 'batched_size')
-        3.times { BatchedSizeWorker.perform_async('bar', 1) }
+        batch = subject.new(BatchedSizeWorker.name, 'batched_size', 'foo_option')
+        3.times { BatchedSizeWorker.perform_async('foo_option', 'bar', 1) }
         expect(batch.size).to eq(3)
       end
     end
   end
 
   private
-  def expect_batch(klass, queue)
-    expect(klass).to_not have_enqueued_job('bar')
-    batch = subject.new(klass.name, queue)
+  def expect_batch(klass, queue, queue_option)
+    expect(klass).to_not have_enqueued_job('foo_option', 'bar')
+    batch = subject.new(klass.name, queue, queue_option)
     stats = subject.all
     expect(batch.size).to eq(1)
     expect(stats.size).to eq(1)
     expect(stats.first.worker_class).to eq(klass.name)
     expect(stats.first.queue).to eq(queue)
-    expect(batch.pluck).to eq [['bar']]
+    expect(batch.pluck(batch.size)).to eq [['foo_option', 'bar']]
   end
 end

--- a/spec/support/test_workers.rb
+++ b/spec/support/test_workers.rb
@@ -8,27 +8,7 @@ end
 class BatchedSizeWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :batched_size, batch_flush_size: 3, batch_size: 2
-
-  def perform(foo)
-  end
-end
-
-class BatchedIntervalWorker
-  include Sidekiq::Worker
-
-  sidekiq_options queue: :batched_interval, batch_flush_interval: 3600
-
-  def perform(foo)
-  end
-end
-
-class BatchedBothWorker
-  include Sidekiq::Worker
-
-  sidekiq_options(
-    queue: :batched_both, batch_flush_interval: 3600, batch_flush_size: 3
-  )
+  sidekiq_options grouping: true, queue: :batched_size, max_calls_per_min: 2
 
   def perform(foo)
   end
@@ -38,7 +18,7 @@ class BatchedUniqueArgsWorker
   include Sidekiq::Worker
 
   sidekiq_options(
-    queue: :batched_unique_args, batch_flush_size: 3, batch_unique: true
+    grouping: true, queue: :batched_unique_args, max_calls_per_min: 3, batch_unique: true
   )
 
   def perform(foo)


### PR DESCRIPTION
## Summary

The [original repo](https://github.com/gzigzigzeo/sidekiq-grouping) where the code comes from is really great and almost fitted what I needed to make Responsys calls batched in a cleanish way.

I'll detail the original features then what I changed/added.
## A long time ago, in a repo not so far away

I'd define sidekiq-grouping as a Sidekiq middleware that acts as a filter before jobs get actually pushed to Sidekiq queues. If sidekiq_options are defined within the worker class and include sidekiq-grouping settings then it'll be considered a batch and the job will be deviated to a temporary queue in Redis, waiting for the right time to be flushed.

When all the criterias are filled, all the jobs that are in the same temp queue are submitted to Sidekiq in one single time. 

Here is an example of how _ORIGINALLY_ sidekiq-grouping used to work (I used the [README](https://github.com/gzigzigzeo/sidekiq-grouping/blob/master/README.md)):

``` ruby
# You define a Sidekiq Job
class SidekiqJobWorker
  include Sidekiq::Worker

  sidekiq_options(
    queue: :batched_jobs,
    batch_flush_size: 30,     # Jobs will be combined when queue size exceeds 30
    batch_flush_interval: 60 # Jobs will be combined every 60 seconds
  )

  def perform(batch_data)
  end
end
```

``` ruby
# You enqueue async jobs
SidekiqJobWorker.perform_async("arg1", "arg2")
SidekiqJobWorker.perform_async("arg3", "arg4")
SidekiqJobWorker.perform_async("arg5", "arg6")
```

``` ruby
# After a while, the perform method gets called:
def perform(batch_data)
    # Here you have access to the data.
    #
    # -> Only one parameter is allowed for the perform method when it's a s-g job.
    #
    # The batch_data comes in as follows:
    # [
    #   ["arg1", "arg2"],
    #   ["arg3", "arg4"],
    #   ["arg5", "arg6"]
    # ]
end
```
## Yes but how about Oracle Responsys API?

Responsys has an API throttle policy that limits the number of calls per minute for their Interact API. The rules are:
1 - The main factor is the number of calls per minute **allowed for that specific method**. It can be different for each method of the API. It can be 30, 100, 1000...
3 - The number of records per call: 200 maximum.

So let's make some changes to adapt the GEM based on these rules.
## Actual changes
### Global settings (in a Rails initializer for example):

``` ruby
Sidekiq::Grouping::Config.enabled = true
Sidekiq::Grouping::Config.poll_interval = 3 # not changed
Sidekiq::Grouping::Config.batch_flush_interval = 60 # not changed
Sidekiq::Grouping::Config.max_records_per_call = 200 # default value
Sidekiq::Grouping::Config.max_calls_per_minute = 30 # default value
```
- poll_interval (sec): internal interval to check every single batch if flushable or not.
- enabled: if turned to false, the jobs are enqueued but not processed. (i.e for test or local environments)
- batch_flush_interval (sec): the interval a batch should be flushed.
### Sidekiq options

Options specific to a Job.

``` ruby
 sidekiq_options(
   grouping: true,
   queue: :responsys_batches, # not changed
   max_calls_per_minute: 150,
   max_records_per_call: 200
 )
```
- grouping: there was no flag that could be set for a batch job. The GEM was looking for its own specific settings and if one was set then it knew it was a batch. A boolean makes more sense for everybody.
- queue: nothing has changed here, it's the regular Sidekiq param that is used to move the job to the right queue.
- max_calls_per_minute and max_records_per_call are specific to Responsys and that particular Job.
### The input and output data is different

I needed to group jobs following the same pattern. I couldn't just group jobs of a same method together because an API call to Responsys acts most of the time on one Interact Object and even sometimes with different merge rules. 
So I changed the way the jobs are temporarily enqueued and added a _queue_option_ argument to all jobs.
It is the first parameter of a batched job, is mandatory and it needs to be a String. It's also returned in the perform data.
It will be used to group the jobs against the same queue option and the same job class.

**Example:**

``` ruby
# For these Sidekiq options
 sidekiq_options(
   grouping: true,
   queue: :responsys_batches,
   max_calls_per_minute: 3,
   max_records_per_call: 2
 )
```

``` ruby
# Input. Enqueue single modifications -> one job = one record to edit
MergeListMembersWorker.perform_async("CONTACTS_LIST,update_record", "user1@email.com", "1000") #1
MergeListMembersWorker.perform_async("CONTACTS_LIST,update_record", "user2@email.com", "2000") #2
MergeListMembersWorker.perform_async("CONTACTS_LIST,update_record", "user3@email.com", "3000") #3
MergeListMembersWorker.perform_async("CONTACTS_LIST,update_record", "user4@email.com", "4000") #4
MergeListMembersWorker.perform_async("CONTACTS_LIST,update_record", "user5@email.com", "5000") #5
MergeListMembersWorker.perform_async("CONTACTS_LIST,update_record", "user6@email.com", "6000") #6
MergeListMembersWorker.perform_async("CONTACTS_LIST,update_record", "user7@email.com", "7000") #7
```

``` ruby
# Output (#perform)
# t + 60s
#3 calls of 2 records = 6 records to update
{
  "queue_option" => "CONTACTS_LIST,update_record",
  "chunks" => [
    [
      ["CONTACTS_LIST,update_record", "user1@email.com", "1000"],
      ["CONTACTS_LIST,update_record", "user2@email.com", "2000"]
    ],
    [
      ["CONTACTS_LIST,update_record", "user3@email.com", "3000"],
      ["CONTACTS_LIST,update_record", "user4@email.com", "4000"]
    ],
    [
      ["CONTACTS_LIST,update_record", "user5@email.com", "5000"],
      ["CONTACTS_LIST,update_record", "user6@email.com", "6000"]
    ]
  ]
}

# t + 120s
#1 call of 1 records = 1 record to update
{
  "queue_option" => "option",
  "chunks" => [
    [
      ["CONTACTS_LIST,update_record", "user7@email.com", "7000"]
    ]
  ]
}
```

The Job is now able to handle the calls with the appropriate number of records.

I also updated the Web UI to add the queue option. To save real estate on the page, I grouped the workers per queue name. That also looks more visible to me if there is more than one queue.
## What's next?
- Add coverage on actor.rb which is were the number of records and calls are determined. This will be the occasion of cleaning up the code to make it easily to read and test.
- Update README
